### PR TITLE
[Expansion Panel] Implemented new component for v1-beta (Issue #2863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 Changes. Changes everywhere!
 
+## 1.0.0-beta.3
+###### _Jul 29, 2017_
+
+Big thanks to the 8 contributors who made this release possible.
+
+This release is full of bug fixes and documentation improvements following the major
+styling update of the previous release.
+
+##### Component Fixes / Enhancements
+
+- [Drawer] Fix docked not inheriting props (#7590) @foreggs
+- [Dialog] Better fullscreen fix (4deee4b5e3465682996d4dce35e5c60fd040502b) @oliviertassinari
+- [List] Fix padding issue (#7529) @markselby9
+- [test] Remove dead code (4e2cf38ae3181cf38a5796179bfb2887c402b4ac) @oliviertassinari
+- [flow] Fix wrong import (5a88d950bb3e9c7105cfa6b45c796d167827f1d7) @oliviertassinari
+- [Tabs] Fix Scroll button visibility state when child tab items are modified (#7576) @shawnmcknight
+- [TextField] Forward the id to the label & more (#7584) @oliviertassinari
+- [ios] Fix some style issue with Safari iOS (#7588) @oliviertassinari
+
+##### Docs
+
+- [docs] Add example with Create React App (#7485) @akshaynaik404
+- [docs] Minor tweaks to grammar of CSS in JS page (#7530) @mbrookes
+- [docs] Server side fix docs (91a30ee2276d8d06776f6fba831930568974dacc) @oliviertassinari
+- [docs] Fix 'colors' path in imports (#7519) @burnoo
+- [docs] Some fixes after the latest upgrade (#7528) @oliviertassinari
+- [docs] Update for supported components (#7586) @skirunman
+- [docs] Fix small issues I have noticed (#7591) @oliviertassinari
+- [docs] Optional style sheet name (#7594) @oliviertassinari
+- [docs] Use flow weak on the demos as we can't expect users to have flow (cd25e63a214c37ed7945e31aa9b08f02baa17351) @oliviertassinari
+
+##### Core
+
+- [core] Support react@16.0.0-beta.1 (#7561) @oliviertassinari
+- [core] Small fixes of the styling solution (#7572) @oliviertassinari
+- [core] Better themingEnabled logic (#7533) @oliviertassinari
+- [core] Upgrade dependencies and build for the supported targets (#7575) @oliviertassinari
+- [core] Upgrade dependencies (#7539) @oliviertassinari
+- [flow] Increase coverage (6f4b2b3b3773ace568de54aaefbca963ab408b40) @oliviertassinari
+
+## 1.0.0-beta.2
+###### _Jul 23, 2017_
+
+Publish a new version as `v1.0.0-beta.1` was already used.
+
 ## 1.0.0-beta.1
 ###### _Jul 23, 2017_
 

--- a/docs/src/components/AppContent.js
+++ b/docs/src/components/AppContent.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 
-const styleSheet = createStyleSheet('AppContent', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   content: theme.mixins.gutters({
     paddingTop: 80,
     flex: '1 1 100%',

--- a/docs/src/components/AppDrawer.js
+++ b/docs/src/components/AppDrawer.js
@@ -11,7 +11,7 @@ import Divider from 'material-ui/Divider';
 import AppDrawerNavItem from 'docs/src/components/AppDrawerNavItem';
 import Link from 'docs/src/components/Link';
 
-const styleSheet = createStyleSheet('AppDrawer', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: 250,
     backgroundColor: theme.palette.background.paper,

--- a/docs/src/components/AppDrawerNavItem.js
+++ b/docs/src/components/AppDrawerNavItem.js
@@ -9,7 +9,7 @@ import { ListItem } from 'material-ui/List';
 import Button from 'material-ui/Button';
 import Collapse from 'material-ui/transitions/Collapse';
 
-const styleSheet = createStyleSheet('AppDrawerNavItem', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: theme.mixins.gutters({
     borderRadius: 0,
     justifyContent: 'flex-start',

--- a/docs/src/components/AppDrawerNavItem.js
+++ b/docs/src/components/AppDrawerNavItem.js
@@ -64,7 +64,7 @@ class AppDrawerNavItem extends Component {
   };
 
   render() {
-    const { children, classes, title, to } = this.props;
+    const { children, classes, title, to, openImmediately } = this.props;
 
     if (to) {
       return (
@@ -72,8 +72,8 @@ class AppDrawerNavItem extends Component {
           <Button
             component={Link}
             to={to}
-            className={classNames(classes.button, classes.navLinkButton)}
             activeClassName={classes.activeButton}
+            className={classNames(classes.button, classes.navLinkButton)}
             disableRipple
             onClick={this.props.onClick}
           >
@@ -85,7 +85,13 @@ class AppDrawerNavItem extends Component {
 
     return (
       <ListItem className={classes.navItem} disableGutters>
-        <Button className={classes.button} onClick={this.handleClick}>
+        <Button
+          classes={{
+            root: classes.button,
+            label: openImmediately ? 'algolia-lvl0' : '',
+          }}
+          onClick={this.handleClick}
+        >
           {title}
         </Button>
         <Collapse in={this.state.open} transitionDuration="auto" unmountOnExit>

--- a/docs/src/components/AppFrame.js
+++ b/docs/src/components/AppFrame.js
@@ -51,7 +51,7 @@ const styleSheet = createStyleSheet('AppFrame', theme => ({
       width: 'auto',
     },
   },
-  appFrame: {
+  root: {
     display: 'flex',
     alignItems: 'stretch',
     minHeight: '100vh',
@@ -121,7 +121,7 @@ class AppFrame extends Component {
     }
 
     return (
-      <div className={classes.appFrame}>
+      <div className={classes.root}>
         <AppBar className={appBarClassName}>
           <Toolbar>
             <IconButton

--- a/docs/src/components/Demo.js
+++ b/docs/src/components/Demo.js
@@ -11,7 +11,7 @@ import MarkdownElement from 'docs/src/components/MarkdownElement';
 const requireDemos = require.context('docs/src', true, /\.js$/);
 const requireDemoSource = require.context('!raw-loader!docs/src', true, /\.js$/);
 
-const styleSheet = createStyleSheet('Demo', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     position: 'relative',

--- a/docs/src/components/Link.js
+++ b/docs/src/components/Link.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { Link as LinkRouter } from 'react-router';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('Link', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     color: 'inherit',
     textDecoration: 'none',

--- a/docs/src/components/MarkdownDocs.js
+++ b/docs/src/components/MarkdownDocs.js
@@ -7,7 +7,7 @@ import Button from 'material-ui/Button';
 import MarkdownElement from 'docs/src/components/MarkdownElement';
 import Demo from 'docs/src/components/Demo';
 
-const styleSheet = createStyleSheet('MarkdownDocs', {
+const styleSheet = createStyleSheet({
   root: {
     marginBottom: 100,
   },

--- a/docs/src/components/MarkdownElement.js
+++ b/docs/src/components/MarkdownElement.js
@@ -112,6 +112,8 @@ const styleSheet = createStyleSheet('MarkdownElement', theme => ({
     },
     '& table': {
       width: '100%',
+      display: 'block',
+      overflowX: 'auto',
       borderCollapse: 'collapse',
       borderSpacing: 0,
       overflow: 'hidden',
@@ -128,7 +130,7 @@ const styleSheet = createStyleSheet('MarkdownElement', theme => ({
     },
     '& td': {
       borderBottom: `1px solid ${theme.palette.text.lightDivider}`,
-      padding: `${theme.spacing.unit}px ${theme.spacing.unit * 8}px ${theme.spacing.unit}px ${theme
+      padding: `${theme.spacing.unit}px ${theme.spacing.unit * 5}px ${theme.spacing.unit}px ${theme
         .spacing.unit * 3}px`,
       textAlign: 'left',
     },
@@ -145,7 +147,7 @@ const styleSheet = createStyleSheet('MarkdownElement', theme => ({
     '& th': {
       whiteSpace: 'pre',
       borderBottom: `1px solid ${theme.palette.text.lightDivider}`,
-      padding: '0 56px 0 24px',
+      padding: `0 ${theme.spacing.unit * 5}px 0 ${theme.spacing.unit * 3}px`,
       textAlign: 'left',
     },
     '& th:last-child': {

--- a/docs/src/components/MarkdownElement.js
+++ b/docs/src/components/MarkdownElement.js
@@ -55,7 +55,7 @@ const anchorLinkStyle = theme => ({
   },
 });
 
-const styleSheet = createStyleSheet('MarkdownElement', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     fontFamily: theme.typography.fontFamily,
     marginTop: theme.spacing.unit * 2,

--- a/docs/src/pages/Home.js
+++ b/docs/src/pages/Home.js
@@ -8,38 +8,43 @@ import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 import muiLogo from 'docs/src/assets/images/material-ui-logo.svg';
 
-const styleSheet = createStyleSheet('Home', theme => {
-  return {
-    root: {
-      flex: '1 0 100%',
+const styleSheet = createStyleSheet(theme => ({
+  root: {
+    flex: '1 0 100%',
+  },
+  hero: {
+    minHeight: '100vh', // Makes the hero full height until we get some more content.
+    flex: '0 0 auto',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor:
+      theme.palette.type === 'light' ? theme.palette.primary[500] : theme.palette.primary[800],
+    color: theme.palette.getContrastText(theme.palette.primary[500]),
+  },
+  content: {
+    paddingTop: theme.spacing.unit * 8,
+    paddingBottom: theme.spacing.unit * 8,
+    textAlign: 'center',
+    [theme.breakpoints.up('sm')]: {
+      paddingTop: theme.spacing.unit * 16,
+      paddingBottom: theme.spacing.unit * 16,
     },
-    hero: {
-      minHeight: '100vh', // Makes the hero full height until we get some more content.
-      flex: '0 0 auto',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      backgroundColor: theme.palette.primary[500],
-      color: theme.palette.getContrastText(theme.palette.primary[500]),
-    },
-    content: {
-      padding: '60px 30px',
-      textAlign: 'center',
-      [theme.breakpoints.up('sm')]: {
-        padding: '120px 30px',
-      },
-    },
-    button: {
-      marginTop: 20,
-    },
-    logo: {
-      margin: '20px -40%',
-      width: '100%',
-      height: '40vw',
-      maxHeight: 230,
-    },
-  };
-});
+  },
+  text: {
+    paddingLeft: theme.spacing.unit * 4,
+    paddingRight: theme.spacing.unit * 4,
+  },
+  button: {
+    marginTop: 20,
+  },
+  logo: {
+    margin: '20px 0',
+    width: '100%',
+    height: '40vw',
+    maxHeight: 230,
+  },
+}));
 
 function Home(props) {
   const classes = props.classes;
@@ -49,20 +54,22 @@ function Home(props) {
       <div className={classes.hero}>
         <div className={classes.content}>
           <img src={muiLogo} alt="Material-UI Logo" className={classes.logo} />
-          <Typography type="display2" component="h1" color="inherit">
-            {'Material-UI'}
-          </Typography>
-          <Typography type="subheading" component="h2" color="inherit">
-            {"A React component library implementing Google's Material Design"}
-          </Typography>
-          <Button
-            component={Link}
-            className={classes.button}
-            raised
-            to="/getting-started/installation"
-          >
-            {'Get Started'}
-          </Button>
+          <div className={classes.text}>
+            <Typography type="display2" component="h1" color="inherit">
+              {'Material-UI'}
+            </Typography>
+            <Typography type="subheading" component="h2" color="inherit">
+              {"A React component library implementing Google's Material Design"}
+            </Typography>
+            <Button
+              component={Link}
+              className={classes.button}
+              raised
+              to="/getting-started/installation"
+            >
+              {'Get Started'}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/docs/src/pages/component-api/Avatar/Avatar.md
+++ b/docs/src/pages/component-api/Avatar/Avatar.md
@@ -7,7 +7,7 @@
 ## Props
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| alt | string | '' | Used in combination with `src` or `srcSet` to provide an alt attribute for the rendered `img` element. |
+| alt | string |  | Used in combination with `src` or `srcSet` to provide an alt attribute for the rendered `img` element. |
 | children | Element |  | Used to render icon or text elements inside the Avatar. `src` and `alt` props will not be used and no `img` will be rendered by default.<br>This can be an element, or just a string. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | union:&nbsp;string<br>&nbsp;Function<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |

--- a/docs/src/pages/component-api/ExpansionPanel/ExpansionPanel.md
+++ b/docs/src/pages/component-api/ExpansionPanel/ExpansionPanel.md
@@ -1,0 +1,44 @@
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# ExpansionPanel
+
+
+
+## Props
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| children | element |  | The content of the expansion panel. |
+| classes | object |  | Useful to extend the style applied to components. |
+| defaultExpanded | bool |  | If `true`, expands the panel by default. |
+| disabled | bool | false | If `true`, the panel should be displayed in a disabled state. |
+| expandIcon | element | null | The icon to display as the expand indicator. |
+| expanded | bool |  | If `true`, expands the panel, otherwise collapse it. Setting this prop enables control over the panel. |
+| headerTitle | element |  | Sets the title of the panel header. |
+| headerTitleProps | object |  | Properties applied to the header title Typography element. |
+| onChange | function | () => {} | Callback fired on every expand/collapse state change. |
+| unmountOnExit | bool | false | Unmounts the child elements after collapse the panel. |
+
+Any other properties supplied will be spread to the root element.
+
+## CSS API
+
+You can overrides all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+- `root`
+- `disabled`
+- `expanded`
+- `header`
+- `headerFocused`
+- `headerExpanded`
+- `headerHover`
+- `headerDisabled`
+- `expandButton`
+- `expandButtonOpen`
+- `focusHolder`
+
+Have a look at [overriding with classes](/customization/overrides#overriding-with-classes)
+section for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiExpansionPanel`.

--- a/docs/src/pages/component-api/Progress/LinearProgress.md
+++ b/docs/src/pages/component-api/Progress/LinearProgress.md
@@ -21,13 +21,14 @@ You can overrides all the class names injected by Material-UI thanks to the `cla
 This property accepts the following keys:
 - `root`
 - `primaryColor`
-- `accentColor`
-- `primaryBar`
+- `primaryColorBar`
 - `primaryDashed`
-- `primaryBufferBar2`
-- `accentBar`
+- `accentColor`
+- `accentColorBar`
 - `accentDashed`
-- `accentBufferBar2`
+- `bar`
+- `dashed`
+- `bufferBar2`
 - `rootBuffer`
 - `rootQuery`
 - `indeterminateBar1`

--- a/docs/src/pages/component-api/styles/MuiThemeProvider.md
+++ b/docs/src/pages/component-api/styles/MuiThemeProvider.md
@@ -8,6 +8,7 @@
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | element |  | You can only provide a single element. |
+| sheetsManager | object |  | The sheetsManager is used in order to only inject once a style sheet in a page for a given theme object. You should provide on the server. |
 | <span style="color: #31a148">theme *</span> | union:&nbsp;object<br>&nbsp;func<br> |  | A theme object. |
 
 Any other properties supplied will be spread to the root element.

--- a/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/ButtonAppBar.js
@@ -10,7 +10,7 @@ import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import MenuIcon from 'material-ui-icons/Menu';
 
-const styleSheet = createStyleSheet('ButtonAppBar', {
+const styleSheet = createStyleSheet({
   root: {
     marginTop: 30,
     width: '100%',

--- a/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/component-demos/app-bar/SimpleAppBar.js
@@ -7,7 +7,7 @@ import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('SimpleAppBar', {
+const styleSheet = createStyleSheet({
   root: {
     marginTop: 30,
     width: '100%',

--- a/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
@@ -121,7 +121,7 @@ function getSuggestions(value) {
       });
 }
 
-const styleSheet = createStyleSheet('IntegrationAutosuggest', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     position: 'relative',

--- a/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/component-demos/autocomplete/IntegrationAutosuggest.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-array-index-key */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/avatars/IconAvatars.js
+++ b/docs/src/pages/component-demos/avatars/IconAvatars.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/avatars/IconAvatars.js
+++ b/docs/src/pages/component-demos/avatars/IconAvatars.js
@@ -10,7 +10,7 @@ import FolderIcon from 'material-ui-icons/Folder';
 import PageviewIcon from 'material-ui-icons/Pageview';
 import AssignmentIcon from 'material-ui-icons/Assignment';
 
-const styleSheet = createStyleSheet('IconAvatars', {
+const styleSheet = createStyleSheet({
   avatar: {
     margin: 10,
   },

--- a/docs/src/pages/component-demos/avatars/ImageAvatars.js
+++ b/docs/src/pages/component-demos/avatars/ImageAvatars.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/avatars/ImageAvatars.js
+++ b/docs/src/pages/component-demos/avatars/ImageAvatars.js
@@ -8,7 +8,7 @@ import Avatar from 'material-ui/Avatar';
 import remyImage from 'docs/src/assets/images/remy.jpg';
 import uxecoImage from 'docs/src/assets/images/uxceo-128.jpg';
 
-const styleSheet = createStyleSheet('ImageAvatars', {
+const styleSheet = createStyleSheet({
   row: {
     display: 'flex',
     justifyContent: 'center',

--- a/docs/src/pages/component-demos/avatars/LetterAvatars.js
+++ b/docs/src/pages/component-demos/avatars/LetterAvatars.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/avatars/LetterAvatars.js
+++ b/docs/src/pages/component-demos/avatars/LetterAvatars.js
@@ -7,7 +7,7 @@ import Avatar from 'material-ui/Avatar';
 import deepOrange from 'material-ui/colors/deepOrange';
 import deepPurple from 'material-ui/colors/deepPurple';
 
-const styleSheet = createStyleSheet('LetterAvatars', {
+const styleSheet = createStyleSheet({
   avatar: {
     margin: 10,
   },

--- a/docs/src/pages/component-demos/badges/SimpleBadge.js
+++ b/docs/src/pages/component-demos/badges/SimpleBadge.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/badges/SimpleBadge.js
+++ b/docs/src/pages/component-demos/badges/SimpleBadge.js
@@ -7,7 +7,7 @@ import Badge from 'material-ui/Badge';
 import MailIcon from 'material-ui-icons/Mail';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('SimpleBadge', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   badge: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/LabelBottomNavigation.js
@@ -9,7 +9,7 @@ import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('LabelBottomNavigation', {
+const styleSheet = createStyleSheet({
   root: {
     width: 500,
   },

--- a/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/component-demos/bottom-navigation/SimpleBottomNavigation.js
@@ -8,7 +8,7 @@ import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
 
-const styleSheet = createStyleSheet('SimpleBottomNavigation', {
+const styleSheet = createStyleSheet({
   root: {
     width: 500,
   },

--- a/docs/src/pages/component-demos/buttons/FlatButtons.js
+++ b/docs/src/pages/component-demos/buttons/FlatButtons.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/buttons/FlatButtons.js
+++ b/docs/src/pages/component-demos/buttons/FlatButtons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('FlatButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/component-demos/buttons/FloatingActionButtons.js
@@ -7,7 +7,7 @@ import Button from 'material-ui/Button';
 import AddIcon from 'material-ui-icons/Add';
 import ModeEditIcon from 'material-ui-icons/ModeEdit';
 
-const styleSheet = createStyleSheet('FloatingActionButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/IconButtons.js
+++ b/docs/src/pages/component-demos/buttons/IconButtons.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/buttons/IconButtons.js
+++ b/docs/src/pages/component-demos/buttons/IconButtons.js
@@ -8,7 +8,7 @@ import IconButton from 'material-ui/IconButton';
 import DeleteIcon from 'material-ui-icons/Delete';
 import AddShoppingCartIcon from 'material-ui-icons/AddShoppingCart';
 
-const styleSheet = createStyleSheet('IconButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/buttons/RaisedButtons.js
+++ b/docs/src/pages/component-demos/buttons/RaisedButtons.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/buttons/RaisedButtons.js
+++ b/docs/src/pages/component-demos/buttons/RaisedButtons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('RaisedButtons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   button: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/cards/NowPlayingCard.js
+++ b/docs/src/pages/component-demos/cards/NowPlayingCard.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/cards/NowPlayingCard.js
+++ b/docs/src/pages/component-demos/cards/NowPlayingCard.js
@@ -11,7 +11,7 @@ import PlayArrowIcon from 'material-ui-icons/PlayArrow';
 import SkipNextIcon from 'material-ui-icons/SkipNext';
 import albumCover from 'docs/src/assets/images/live-from-space.jpg';
 
-const styleSheet = createStyleSheet('NowPlayingCard', {
+const styleSheet = createStyleSheet({
   card: {
     display: 'flex',
   },

--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/component-demos/cards/RecipeReviewCard.js
@@ -15,7 +15,7 @@ import ShareIcon from 'material-ui-icons/Share';
 import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
 import paellaImage from 'docs/src/assets/images/paella.jpg';
 
-const styleSheet = createStyleSheet('RecipeReviewCard', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   card: { maxWidth: 400 },
   expand: {
     transform: 'rotate(0deg)',

--- a/docs/src/pages/component-demos/cards/SimpleCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleCard.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/cards/SimpleCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleCard.js
@@ -7,7 +7,7 @@ import Card, { CardActions, CardContent } from 'material-ui/Card';
 import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('SimpleCard', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   card: {
     minWidth: 275,
   },

--- a/docs/src/pages/component-demos/cards/SimpleMediaCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleMediaCard.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/cards/SimpleMediaCard.js
+++ b/docs/src/pages/component-demos/cards/SimpleMediaCard.js
@@ -8,7 +8,7 @@ import Button from 'material-ui/Button';
 import Typography from 'material-ui/Typography';
 import reptileImage from 'docs/src/assets/images/contemplative-reptile.jpg';
 
-const styleSheet = createStyleSheet('SimpleMediaCard', {
+const styleSheet = createStyleSheet({
   card: {
     maxWidth: 345,
   },

--- a/docs/src/pages/component-demos/chips/Chips.js
+++ b/docs/src/pages/component-demos/chips/Chips.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/chips/Chips.js
+++ b/docs/src/pages/component-demos/chips/Chips.js
@@ -9,7 +9,7 @@ import FaceIcon from 'material-ui-icons/Face';
 import grey from 'material-ui/colors/grey';
 import uxecoImage from 'docs/src/assets/images/uxceo-128.jpg';
 
-const styleSheet = createStyleSheet('Chips', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   chip: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/component-demos/chips/ChipsArray.js
+++ b/docs/src/pages/component-demos/chips/ChipsArray.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/chips/ChipsArray.js
+++ b/docs/src/pages/component-demos/chips/ChipsArray.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Chip from 'material-ui/Chip';
 
-const styleSheet = createStyleSheet('ChipsArray', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   chip: {
     margin: theme.spacing.unit / 2,
   },

--- a/docs/src/pages/component-demos/dialogs/AlertDialog.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialog.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import Button from 'material-ui/Button';

--- a/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/component-demos/dialogs/AlertDialogSlide.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import Button from 'material-ui/Button';

--- a/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/component-demos/dialogs/ConfirmationDialog.js
@@ -106,7 +106,7 @@ ConfirmationDialog.propTypes = {
   selectedValue: PropTypes.string,
 };
 
-const styleSheet = createStyleSheet('ConfirmationDialogDemo', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/component-demos/dialogs/FullScreenDialog.js
@@ -14,7 +14,7 @@ import Typography from 'material-ui/Typography';
 import CloseIcon from 'material-ui-icons/Close';
 import Slide from 'material-ui/transitions/Slide';
 
-const styleSheet = createStyleSheet('FullScreenDialog', {
+const styleSheet = createStyleSheet({
   appBar: {
     position: 'relative',
   },

--- a/docs/src/pages/component-demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/component-demos/dialogs/SimpleDialog.js
@@ -15,7 +15,7 @@ import blue from 'material-ui/colors/blue';
 
 const emails = ['username@gmail.com', 'user02@gmail.com'];
 
-const styleSheet = createStyleSheet('SimpleDialog', () => ({
+const styleSheet = createStyleSheet(() => ({
   avatar: {
     background: blue[100],
     color: blue[600],

--- a/docs/src/pages/component-demos/dividers/InsetDividers.js
+++ b/docs/src/pages/component-demos/dividers/InsetDividers.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/dividers/InsetDividers.js
+++ b/docs/src/pages/component-demos/dividers/InsetDividers.js
@@ -9,7 +9,7 @@ import Divider from 'material-ui/Divider';
 import FolderIcon from 'material-ui-icons/Folder';
 import ImageIcon from 'material-ui-icons/Image';
 
-const styleSheet = createStyleSheet('InsetDividers', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',

--- a/docs/src/pages/component-demos/dividers/ListDividers.js
+++ b/docs/src/pages/component-demos/dividers/ListDividers.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/dividers/ListDividers.js
+++ b/docs/src/pages/component-demos/dividers/ListDividers.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Divider from 'material-ui/Divider';
 
-const styleSheet = createStyleSheet('ListDividers', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/drawers/UndockedDrawer.js
+++ b/docs/src/pages/component-demos/drawers/UndockedDrawer.js
@@ -15,7 +15,7 @@ import MailIcon from 'material-ui-icons/Mail';
 import DeleteIcon from 'material-ui-icons/Delete';
 import ReportIcon from 'material-ui-icons/Report';
 
-const styleSheet = createStyleSheet('UndockedDrawer', {
+const styleSheet = createStyleSheet({
   list: {
     width: 250,
     flex: 'initial',

--- a/docs/src/pages/component-demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/component-demos/expansion-panels/ControlledExpansionPanels.js
@@ -1,0 +1,92 @@
+// @flow weak
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
+import ExpansionPanel from 'material-ui/ExpansionPanel';
+import Typography from 'material-ui/Typography';
+import { CardActions } from 'material-ui/Card';
+import Button from 'material-ui/Button';
+import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
+
+const styleSheet = createStyleSheet({
+  root: {
+    marginTop: 30,
+    width: '100%',
+  },
+  content: {
+    paddingLeft: 24,
+    paddingRight: 24,
+    paddingBottom: 24,
+  },
+});
+
+class ControlledExpansionPanels extends Component {
+  state = {
+    expanded: null,
+  };
+
+  handleChange = (panel, expand) => {
+    this.setState({
+      expanded: expand ? panel.props.id : false,
+    });
+  };
+
+  render() {
+    const classes = this.props.classes;
+    return (
+      <div className={classes.root}>
+        <ExpansionPanel
+          headerTitle="Expansion panel #1"
+          expandIcon={<ExpandMoreIcon />}
+          id="p1"
+          expanded={this.state.expanded === 'p1'}
+          onChange={this.handleChange}
+        >
+          <Typography className={classes.content} type="body1" component="p">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget.
+          </Typography>
+          <CardActions>
+            <Button dense color="primary">
+              Share
+            </Button>
+            <Button dense color="primary">
+              Learn More
+            </Button>
+          </CardActions>
+        </ExpansionPanel>
+        <ExpansionPanel
+          headerTitle="Expansion panel #2"
+          expandIcon={<ExpandMoreIcon />}
+          id="p2"
+          expanded={this.state.expanded === 'p2'}
+          onChange={this.handleChange}
+        >
+          <Typography className={classes.content} type="body1" component="p">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanel>
+        <ExpansionPanel
+          headerTitle="Expansion panel #3"
+          expandIcon={<ExpandMoreIcon />}
+          id="p3"
+          expanded={this.state.expanded === 'p3'}
+          onChange={this.handleChange}
+        >
+          <Typography className={classes.content} type="body1" component="p">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanel>
+      </div>
+    );
+  }
+}
+
+ControlledExpansionPanels.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(ControlledExpansionPanels);

--- a/docs/src/pages/component-demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/component-demos/expansion-panels/ControlledExpansionPanels.js
@@ -6,6 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import ExpansionPanel from 'material-ui/ExpansionPanel';
 import Typography from 'material-ui/Typography';
 import { CardActions } from 'material-ui/Card';
+import Divider from 'material-ui/Divider';
 import Button from 'material-ui/Button';
 import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
 
@@ -15,9 +16,12 @@ const styleSheet = createStyleSheet({
     width: '100%',
   },
   content: {
-    paddingLeft: 24,
-    paddingRight: 24,
-    paddingBottom: 24,
+    padding: 24,
+  },
+  actions: {
+    height: 64,
+    padding: [0, 8],
+    justifyContent: 'flex-end',
   },
 });
 
@@ -39,15 +43,17 @@ class ControlledExpansionPanels extends Component {
         <ExpansionPanel
           headerTitle="Expansion panel #1"
           expandIcon={<ExpandMoreIcon />}
-          id="p1"
-          expanded={this.state.expanded === 'p1'}
+          id="panel1"
+          expanded={this.state.expanded === 'panel1'}
           onChange={this.handleChange}
+          unmountOnExit
         >
-          <Typography className={classes.content} type="body1" component="p">
+          <Typography className={classes.content} component="p">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
             sit amet blandit leo lobortis eget.
           </Typography>
-          <CardActions>
+          <Divider />
+          <CardActions className={classes.actions}>
             <Button dense color="primary">
               Share
             </Button>
@@ -59,11 +65,11 @@ class ControlledExpansionPanels extends Component {
         <ExpansionPanel
           headerTitle="Expansion panel #2"
           expandIcon={<ExpandMoreIcon />}
-          id="p2"
-          expanded={this.state.expanded === 'p2'}
+          id="panel2"
+          expanded={this.state.expanded === 'panel2'}
           onChange={this.handleChange}
         >
-          <Typography className={classes.content} type="body1" component="p">
+          <Typography className={classes.content} component="p">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
             sit amet blandit leo lobortis eget.
           </Typography>
@@ -71,11 +77,11 @@ class ControlledExpansionPanels extends Component {
         <ExpansionPanel
           headerTitle="Expansion panel #3"
           expandIcon={<ExpandMoreIcon />}
-          id="p3"
-          expanded={this.state.expanded === 'p3'}
+          id="panel3"
+          expanded={this.state.expanded === 'panel3'}
           onChange={this.handleChange}
         >
-          <Typography className={classes.content} type="body1" component="p">
+          <Typography className={classes.content} component="p">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
             sit amet blandit leo lobortis eget.
           </Typography>

--- a/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
@@ -13,8 +13,7 @@ const styleSheet = createStyleSheet({
     width: '100%',
   },
   content: {
-    paddingLeft: 24,
-    paddingRight: 24,
+    padding: 24,
   },
 });
 
@@ -22,14 +21,8 @@ function SimpleExpansionPanel(props) {
   const classes = props.classes;
   return (
     <div className={classes.root}>
-      <ExpansionPanel headerTitle={'Expansion panel title'} expandIcon={<ExpandMoreIcon />}>
-        <Typography className={classes.content} type="body1" component="p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
-          sit amet blandit leo lobortis eget.
-        </Typography>
-      </ExpansionPanel>
-      <ExpansionPanel headerTitle={'Expansion panel title #2'} expandIcon={<ExpandMoreIcon />}>
-        <Typography className={classes.content} type="body1" component="p">
+      <ExpansionPanel headerTitle="Expansion panel title" expandIcon={<ExpandMoreIcon />}>
+        <Typography className={classes.content} component="p">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
           sit amet blandit leo lobortis eget.
         </Typography>

--- a/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
@@ -1,0 +1,45 @@
+// @flow weak
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, createStyleSheet } from 'material-ui/styles';
+import ExpansionPanel from 'material-ui/ExpansionPanel';
+import Typography from 'material-ui/Typography';
+import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
+
+const styleSheet = createStyleSheet({
+  root: {
+    marginTop: 30,
+    width: '100%',
+  },
+  content: {
+    paddingLeft: 24,
+    paddingRight: 24,
+  },
+});
+
+function SimpleExpansionPanel(props) {
+  const classes = props.classes;
+  return (
+    <div className={classes.root}>
+      <ExpansionPanel headerTitle={'Expansion panel title'} expandIcon={<ExpandMoreIcon />}>
+        <Typography className={classes.content} type="body1" component="p">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+          sit amet blandit leo lobortis eget.
+        </Typography>
+      </ExpansionPanel>
+      <ExpansionPanel headerTitle={'Expansion panel title #2'} expandIcon={<ExpandMoreIcon />}>
+        <Typography className={classes.content} type="body1" component="p">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+          sit amet blandit leo lobortis eget.
+        </Typography>
+      </ExpansionPanel>
+    </div>
+  );
+}
+
+SimpleExpansionPanel.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styleSheet)(SimpleExpansionPanel);

--- a/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/component-demos/expansion-panels/SimpleExpansionPanel.js
@@ -21,7 +21,11 @@ function SimpleExpansionPanel(props) {
   const classes = props.classes;
   return (
     <div className={classes.root}>
-      <ExpansionPanel headerTitle="Expansion panel title" expandIcon={<ExpandMoreIcon />}>
+      <ExpansionPanel
+        headerTitle="Expansion panel title"
+        expandIcon={<ExpandMoreIcon />}
+        defaultExpanded
+      >
         <Typography className={classes.content} component="p">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
           sit amet blandit leo lobortis eget.

--- a/docs/src/pages/component-demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/component-demos/expansion-panels/expansion-panels.md
@@ -6,11 +6,11 @@ components: ExpansionPanel
 
 The [Expansion panel](https://material.io/guidelines/components/expansion-panels.html), can contain creation flows and allow lightweight editing of an element.
 
-## Simple Expansion panel
+## Simple Expansion Panel
 
 {{demo='pages/component-demos/expansion-panels/SimpleExpansionPanel.js'}}
 
-## Accordion
+## Accordion - controlled Expansion Panel
 
 Extend the default panel behavior to create an accordion with the `ExpansionPanel` component.
 

--- a/docs/src/pages/component-demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/component-demos/expansion-panels/expansion-panels.md
@@ -1,0 +1,17 @@
+---
+components: ExpansionPanel
+---
+
+# Expansion Panel
+
+The [Expansion panel](https://material.io/guidelines/components/expansion-panels.html), can contain creation flows and allow lightweight editing of an element.
+
+## Simple Expansion panel
+
+{{demo='pages/component-demos/expansion-panels/SimpleExpansionPanel.js'}}
+
+## Accordion
+
+Extend the default panel behavior to create an accordion with the `ExpansionPanel` component.
+
+{{demo='pages/component-demos/expansion-panels/ControlledExpansionPanels.js'}}

--- a/docs/src/pages/component-demos/lists/CheckboxList.js
+++ b/docs/src/pages/component-demos/lists/CheckboxList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/CheckboxList.js
+++ b/docs/src/pages/component-demos/lists/CheckboxList.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
 import CommentIcon from 'material-ui-icons/Comment';
 
-const styleSheet = createStyleSheet('CheckboxList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/component-demos/lists/CheckboxListSecondary.js
@@ -8,7 +8,7 @@ import Checkbox from 'material-ui/Checkbox';
 import Avatar from 'material-ui/Avatar';
 import remyImage from 'docs/src/assets/images/remy.jpg';
 
-const styleSheet = createStyleSheet('CheckboxListSecondary', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/FolderList.js
+++ b/docs/src/pages/component-demos/lists/FolderList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/FolderList.js
+++ b/docs/src/pages/component-demos/lists/FolderList.js
@@ -7,7 +7,7 @@ import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
 import FolderIcon from 'material-ui-icons/Folder';
 
-const styleSheet = createStyleSheet('FolderList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/InsetList.js
+++ b/docs/src/pages/component-demos/lists/InsetList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/InsetList.js
+++ b/docs/src/pages/component-demos/lists/InsetList.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemIcon, ListItemText } from 'material-ui/List';
 import StarIcon from 'material-ui-icons/Star';
 
-const styleSheet = createStyleSheet('InsetList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/InteractiveList.js
+++ b/docs/src/pages/component-demos/lists/InteractiveList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
@@ -34,7 +34,6 @@ const styleSheet = createStyleSheet(theme => ({
 
 function generate(element) {
   return [0, 1, 2].map(value =>
-    // $FlowFixMe https://github.com/facebook/flow/issues/4172
     cloneElement(element, {
       key: value,
     }),

--- a/docs/src/pages/component-demos/lists/InteractiveList.js
+++ b/docs/src/pages/component-demos/lists/InteractiveList.js
@@ -19,7 +19,7 @@ import Typography from 'material-ui/Typography';
 import FolderIcon from 'material-ui-icons/Folder';
 import DeleteIcon from 'material-ui-icons/Delete';
 
-const styleSheet = createStyleSheet('InteractiveList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     maxWidth: 752,

--- a/docs/src/pages/component-demos/lists/SimpleList.js
+++ b/docs/src/pages/component-demos/lists/SimpleList.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/SimpleList.js
+++ b/docs/src/pages/component-demos/lists/SimpleList.js
@@ -8,7 +8,7 @@ import Divider from 'material-ui/Divider';
 import InboxIcon from 'material-ui-icons/Inbox';
 import DraftsIcon from 'material-ui-icons/Drafts';
 
-const styleSheet = createStyleSheet('SimpleList', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/lists/SwitchListSecondary.js
+++ b/docs/src/pages/component-demos/lists/SwitchListSecondary.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/lists/SwitchListSecondary.js
+++ b/docs/src/pages/component-demos/lists/SwitchListSecondary.js
@@ -14,7 +14,7 @@ import Switch from 'material-ui/Switch';
 import WifiIcon from 'material-ui-icons/Wifi';
 import BluetoothIcon from 'material-ui-icons/Bluetooth';
 
-const styleSheet = createStyleSheet('SwitchListSecondary', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/menus/LongMenu.js
+++ b/docs/src/pages/component-demos/menus/LongMenu.js
@@ -1,8 +1,9 @@
 // @flow weak
 
 import React, { Component } from 'react';
-import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
 import Menu, { MenuItem } from 'material-ui/Menu';
+import MoreVertIcon from 'material-ui-icons/MoreVert';
 
 const options = [
   'None',
@@ -40,15 +41,19 @@ class LongMenu extends Component {
   render() {
     return (
       <div>
-        <Button aria-owns="long-menu" aria-haspopup="true" onClick={this.handleClick}>
-          Open Long Menu
-        </Button>
+        <IconButton
+          aria-label="Delete"
+          aria-owns="long-menu"
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          <MoreVertIcon />
+        </IconButton>
         <Menu
           id="long-menu"
           anchorEl={this.state.anchorEl}
           open={this.state.open}
           onRequestClose={this.handleRequestClose}
-          onClick={this.handleRequestClose}
           style={{ maxHeight: ITEM_HEIGHT * 4.5 }}
           MenuListProps={{
             style: {
@@ -57,7 +62,7 @@ class LongMenu extends Component {
           }}
         >
           {options.map(option =>
-            <MenuItem key={option} selected={option === 'Pyxis'}>
+            <MenuItem key={option} selected={option === 'Pyxis'} onClick={this.handleRequestClose}>
               {option}
             </MenuItem>,
           )}

--- a/docs/src/pages/component-demos/menus/LongMenu.js
+++ b/docs/src/pages/component-demos/menus/LongMenu.js
@@ -42,7 +42,7 @@ class LongMenu extends Component {
     return (
       <div>
         <IconButton
-          aria-label="Delete"
+          aria-label="More"
           aria-owns="long-menu"
           aria-haspopup="true"
           onClick={this.handleClick}

--- a/docs/src/pages/component-demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/component-demos/menus/SimpleListMenu.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/component-demos/menus/SimpleListMenu.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
 
-const styleSheet = createStyleSheet('SimpleListMenu', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,

--- a/docs/src/pages/component-demos/menus/menus.md
+++ b/docs/src/pages/component-demos/menus/menus.md
@@ -32,6 +32,8 @@ If text in a simple menu wraps to a second line, use a simple dialog instead. Si
 
 ## Max height menus
 
+If the height of a menu prevents all menu items from being displayed, the menu can scroll internally.
+
 {{demo='pages/component-demos/menus/LongMenu.js'}}
 
 ## TextField select menus

--- a/docs/src/pages/component-demos/paper/PaperSheet.js
+++ b/docs/src/pages/component-demos/paper/PaperSheet.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/paper/PaperSheet.js
+++ b/docs/src/pages/component-demos/paper/PaperSheet.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('PaperSheet', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: theme.mixins.gutters({
     paddingTop: 16,
     paddingBottom: 16,

--- a/docs/src/pages/component-demos/progress/CircularDeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularDeterminate.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/CircularDeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularDeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('CircularDeterminate', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   progress: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/progress/CircularFab.js
+++ b/docs/src/pages/component-demos/progress/CircularFab.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/CircularFab.js
+++ b/docs/src/pages/component-demos/progress/CircularFab.js
@@ -9,7 +9,7 @@ import Button from 'material-ui/Button';
 import CheckIcon from 'material-ui-icons/Check';
 import SaveIcon from 'material-ui-icons/Save';
 
-const styleSheet = createStyleSheet('CircularFab', {
+const styleSheet = createStyleSheet({
   wrapper: {
     position: 'relative',
   },

--- a/docs/src/pages/component-demos/progress/CircularIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularIndeterminate.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/CircularIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/CircularIndeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { CircularProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('CircularIndeterminate', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   progress: {
     margin: `0 ${theme.spacing.unit * 2}px`,
   },

--- a/docs/src/pages/component-demos/progress/LinearBuffer.js
+++ b/docs/src/pages/component-demos/progress/LinearBuffer.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/LinearBuffer.js
+++ b/docs/src/pages/component-demos/progress/LinearBuffer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearBuffer', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearDeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearDeterminate.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/LinearDeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearDeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearDeterminate', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearIndeterminate.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/LinearIndeterminate.js
+++ b/docs/src/pages/component-demos/progress/LinearIndeterminate.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearIndeterminate', {
+const styleSheet = createStyleSheet({
   root: {
     width: '100%',
     marginTop: 30,

--- a/docs/src/pages/component-demos/progress/LinearQuery.js
+++ b/docs/src/pages/component-demos/progress/LinearQuery.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/progress/LinearQuery.js
+++ b/docs/src/pages/component-demos/progress/LinearQuery.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import { LinearProgress } from 'material-ui/Progress';
 
-const styleSheet = createStyleSheet('LinearQuery', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/selection-controls/Checkboxes.js
+++ b/docs/src/pages/component-demos/selection-controls/Checkboxes.js
@@ -7,7 +7,7 @@ import green from 'material-ui/colors/green';
 import { FormGroup, FormControlLabel } from 'material-ui/Form';
 import Checkbox from 'material-ui/Checkbox';
 
-const styleSheet = createStyleSheet('Checkboxes', {
+const styleSheet = createStyleSheet({
   checked: {
     color: green[500],
   },

--- a/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
+++ b/docs/src/pages/component-demos/selection-controls/RadioButtonsGroup.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import { FormLabel, FormControl, FormControlLabel } from 'material-ui/Form';
 
-const styleSheet = createStyleSheet('RadioButtonsGroup', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   group: {
     margin: `${theme.spacing.unit}px 0`,
   },

--- a/docs/src/pages/component-demos/selection-controls/Switches.js
+++ b/docs/src/pages/component-demos/selection-controls/Switches.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import green from 'material-ui/colors/green';
 import Switch from 'material-ui/Switch';
 
-const styleSheet = createStyleSheet('Switches', {
+const styleSheet = createStyleSheet({
   bar: {},
   checked: {
     color: green[500],

--- a/docs/src/pages/component-demos/snackbars/LongTextSnackbar.js
+++ b/docs/src/pages/component-demos/snackbars/LongTextSnackbar.js
@@ -12,7 +12,7 @@ const action = (
   </Button>
 );
 
-const styleSheet = createStyleSheet('LongTextSnackbar', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     marginTop: theme.spacing.unit * 3,
   },

--- a/docs/src/pages/component-demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/component-demos/snackbars/SimpleSnackbar.js
@@ -8,7 +8,7 @@ import Snackbar from 'material-ui/Snackbar';
 import IconButton from 'material-ui/IconButton';
 import CloseIcon from 'material-ui-icons/Close';
 
-const styleSheet = createStyleSheet('SimpleSnackbar', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   close: {
     width: theme.spacing.unit * 4,
     height: theme.spacing.unit * 4,

--- a/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/DotsMobileStepper.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
 
-const styleSheet = createStyleSheet('DotsMobileStepper', {
+const styleSheet = createStyleSheet({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/ProgressMobileStepper.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import MobileStepper from 'material-ui/MobileStepper';
 
-const styleSheet = createStyleSheet('ProgressMobileStepper', {
+const styleSheet = createStyleSheet({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/TextMobileStepper.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/component-demos/stepper/TextMobileStepper.js
@@ -7,7 +7,7 @@ import MobileStepper from 'material-ui/MobileStepper';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('TextMobileStepper', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     maxWidth: 400,
     flexGrow: 1,

--- a/docs/src/pages/component-demos/tables/BasicTable.js
+++ b/docs/src/pages/component-demos/tables/BasicTable.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/tables/BasicTable.js
+++ b/docs/src/pages/component-demos/tables/BasicTable.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('BasicTable', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tables/EnhancedTable.js
+++ b/docs/src/pages/component-demos/tables/EnhancedTable.js
@@ -79,7 +79,7 @@ class EnhancedTableHead extends Component {
   }
 }
 
-const toolbarStyleSheet = createStyleSheet('EnhancedTableToolbar', theme => ({
+const toolbarStyleSheet = createStyleSheet(theme => ({
   root: {
     paddingRight: 2,
   },
@@ -141,7 +141,7 @@ EnhancedTableToolbar.propTypes = {
 
 EnhancedTableToolbar = withStyles(toolbarStyleSheet)(EnhancedTableToolbar);
 
-const styleSheet = createStyleSheet('EnhancedTable', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   paper: {
     width: '100%',
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/BasicTabs.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabs.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/BasicTabs.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabs.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('BasicTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('BasicTabsWrappedLabel', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
+++ b/docs/src/pages/component-demos/tabs/BasicTabsWrappedLabel.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/CenteredTabs.js
+++ b/docs/src/pages/component-demos/tabs/CenteredTabs.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/tabs/CenteredTabs.js
+++ b/docs/src/pages/component-demos/tabs/CenteredTabs.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
-const styleSheet = createStyleSheet('CenteredTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: theme.spacing.unit * 3,

--- a/docs/src/pages/component-demos/tabs/FullWidthTabs.js
+++ b/docs/src/pages/component-demos/tabs/FullWidthTabs.js
@@ -17,7 +17,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('FullWidthTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     backgroundColor: theme.palette.background.paper,
   },

--- a/docs/src/pages/component-demos/tabs/FullWidthTabs.js
+++ b/docs/src/pages/component-demos/tabs/FullWidthTabs.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonAuto.js
@@ -16,7 +16,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonAuto', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonForce.js
@@ -23,7 +23,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonForce', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 /* eslint-disable react/no-multi-comp */
 
 import React, { Component } from 'react';

--- a/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
+++ b/docs/src/pages/component-demos/tabs/ScrollableTabsButtonPrevent.js
@@ -23,7 +23,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const styleSheet = createStyleSheet('ScrollableTabsButtonPrevent', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     width: '100%',

--- a/docs/src/pages/component-demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/component-demos/text-fields/ComposedTextField.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/component-demos/text-fields/ComposedTextField.js
@@ -8,7 +8,7 @@ import InputLabel from 'material-ui/Input/InputLabel';
 import FormControl from 'material-ui/Form/FormControl';
 import FormHelperText from 'material-ui/Form/FormHelperText';
 
-const styleSheet = createStyleSheet('ComposedTextField', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/Inputs.js
+++ b/docs/src/pages/component-demos/text-fields/Inputs.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/text-fields/Inputs.js
+++ b/docs/src/pages/component-demos/text-fields/Inputs.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
-const styleSheet = createStyleSheet('Inputs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/component-demos/text-fields/TextFieldMargins.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 
-const styleSheet = createStyleSheet('TextFieldMargins', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow weak
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';

--- a/docs/src/pages/component-demos/text-fields/TextFields.js
+++ b/docs/src/pages/component-demos/text-fields/TextFields.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 
-const styleSheet = createStyleSheet('TextFields', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/customization/BusinessVariables.js
+++ b/docs/src/pages/customization/BusinessVariables.js
@@ -6,7 +6,7 @@ import Checkbox from 'material-ui/Checkbox';
 import { createMuiTheme, createStyleSheet, MuiThemeProvider, withStyles } from 'material-ui/styles';
 import orange from 'material-ui/colors/orange';
 
-const styleSheet = createStyleSheet('BusinessCheckbox', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   danger: {
     color: theme.status.danger,
   },

--- a/docs/src/pages/customization/Nested.js
+++ b/docs/src/pages/customization/Nested.js
@@ -8,7 +8,7 @@ import orange from 'material-ui/colors/orange';
 import green from 'material-ui/colors/green';
 import pink from 'material-ui/colors/pink';
 
-const styleSheet = createStyleSheet('NestedCheckbox', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   danger: {
     color: theme.status.color,
   },

--- a/docs/src/pages/customization/OverridesClassNames.js
+++ b/docs/src/pages/customization/OverridesClassNames.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
 // We can inject some CSS into the DOM.
-const styleSheet = createStyleSheet('OverridesClassNames', {
+const styleSheet = createStyleSheet({
   button: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,

--- a/docs/src/pages/customization/OverridesClasses.js
+++ b/docs/src/pages/customization/OverridesClasses.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 
-const styleSheet = createStyleSheet('OverridesClasses', {
+const styleSheet = createStyleSheet({
   root: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -55,13 +55,14 @@ They are easy to debug in development and as short as possible in production:
 
 ## API
 
-### `createStyleSheet(name, styles) => styleSheet`
+### `createStyleSheet([name], styles) => styleSheet`
 
 Generate a new style sheet that represents the style you want to inject in the DOM.
 
 #### Arguments
 
-1. `name` (*String*): The name of the style sheet. Useful for debugging.
+1. `name` (*String* [optional]): The name of the style sheet. Useful for debugging.
+If the value isn't provided, we will try to fallback to the name of the component.
 2. `styles` (*Function | Object*): A function generating the styles or an object.
 
 Use the function if you need to have access to the theme. It's provided as the first argument.
@@ -75,7 +76,7 @@ Use the function if you need to have access to the theme. It's provided as the f
 ```js
 import { createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('MyLink', (theme) => ({
+const styleSheet = createStyleSheet((theme) => ({
   root: {
     color: 'inherit',
     textDecoration: 'inherit',

--- a/docs/src/pages/getting-started/supported-components.md
+++ b/docs/src/pages/getting-started/supported-components.md
@@ -68,7 +68,7 @@ to discuss the approach before submitting a PR.
   - [Leave-behinds](https://www.google.com/design/spec/components/lists-controls.html#lists-controls-types-of-list-controls)
 - **[Menus](https://www.google.com/design/spec/components/menus.html) ✓**
   - **[Button menu](https://www.google.com/design/spec/components/menus.html#menus-usage) (Can be constructed) ✓**
-  - [Scrollable](https://www.google.com/design/spec/components/menus.html#menus-usage)
+  - **[Scrollable](https://www.google.com/design/spec/components/menus.html#menus-usage) ✓**
   - [Cascade](https://www.google.com/design/spec/components/menus.html#menus-usage)
   - [Textfield dropdown](https://www.google.com/design/spec/components/menus.html#menus-behavior) (DropDownMenu)
   - [Contextual / App bar dropdown](https://www.google.com/design/spec/components/menus.html#menus-usage) (IconMenu)
@@ -114,11 +114,11 @@ to discuss the approach before submitting a PR.
   - [Multi-line](https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field)
   - **[Full-width](https://www.google.com/design/spec/components/text-fields.html#text-fields-multi-line-text-field) ✓**
   - [Character counter](https://www.google.com/design/spec/components/text-fields.html#text-fields-character-counter)
-  - **[Auto-complete](https://www.google.com/design/spec/components/text-fields.html#text-fields-auto-complete-text-field) (Can be done using external libraries) ✓**
+  - **[Autocomplete](https://www.google.com/design/spec/components/text-fields.html#text-fields-auto-complete-text-field) (Can be done with external library such as [react-autosuggest](https://github.com/moroshko/react-autosuggest)) ✓**
   - [Search filter](https://www.google.com/design/spec/components/text-fields.html#text-fields-search-filter)
   - [Password](https://www.google.com/design/spec/components/text-fields.html#text-fields-password-input)
-- [Toolbars](https://www.google.com/design/spec/components/toolbars.html)
-- [Tooltips](https://www.google.com/design/spec/components/tooltips.html) (IconButton & TableHeader only)
+- **[Toolbars](https://www.google.com/design/spec/components/toolbars.html) ✓**
+- [Tooltips](https://www.google.com/design/spec/components/tooltips.html)
   - [Desktop](https://www.google.com/design/spec/components/tooltips.html#tooltips-tooltips-desktop-)
   - [Mobile](https://www.google.com/design/spec/components/tooltips.html#tooltips-tooltips-mobile-)
 - [Widgets](https://material.io/guidelines/components/widgets.html)

--- a/docs/src/pages/layout/css-in-js/MediaQuery.js
+++ b/docs/src/pages/layout/css-in-js/MediaQuery.js
@@ -7,7 +7,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('MediaQuery', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     padding: theme.spacing.unit,
     [theme.breakpoints.up('md')]: {

--- a/docs/src/pages/layout/grid/AutoGrid.js
+++ b/docs/src/pages/layout/grid/AutoGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('AutoGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/CenteredGrid.js
+++ b/docs/src/pages/layout/grid/CenteredGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('CenteredGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/FullWidthGrid.js
+++ b/docs/src/pages/layout/grid/FullWidthGrid.js
@@ -6,7 +6,7 @@ import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('FullWidthGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     marginTop: 30,

--- a/docs/src/pages/layout/grid/GuttersGrid.js
+++ b/docs/src/pages/layout/grid/GuttersGrid.js
@@ -8,7 +8,7 @@ import { FormLabel, FormControlLabel } from 'material-ui/Form';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('GuttersGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
   },

--- a/docs/src/pages/layout/grid/InteractiveGrid.js
+++ b/docs/src/pages/layout/grid/InteractiveGrid.js
@@ -8,7 +8,7 @@ import { FormLabel, FormControlLabel } from 'material-ui/Form';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import Paper from 'material-ui/Paper';
 
-const styleSheet = createStyleSheet('InteractiveGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
   },

--- a/docs/src/pages/layout/hidden/BreakpointDown.js
+++ b/docs/src/pages/layout/hidden/BreakpointDown.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointDown', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/BreakpointOnly.js
+++ b/docs/src/pages/layout/hidden/BreakpointOnly.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointOnly', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/BreakpointUp.js
+++ b/docs/src/pages/layout/hidden/BreakpointUp.js
@@ -8,7 +8,7 @@ import Hidden from 'material-ui/Hidden';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('BreakpointUp', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   container: {
     flexGrow: 1,
     paddingTop: 30,

--- a/docs/src/pages/layout/hidden/GridIntegration.js
+++ b/docs/src/pages/layout/hidden/GridIntegration.js
@@ -8,7 +8,7 @@ import Grid from 'material-ui/Grid';
 import withWidth from 'material-ui/utils/withWidth';
 import Typography from 'material-ui/Typography';
 
-const styleSheet = createStyleSheet('GridIntegration', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     flexGrow: 1,
     paddingTop: 42,

--- a/docs/src/pages/style/Color.js
+++ b/docs/src/pages/style/Color.js
@@ -28,7 +28,7 @@ const neutralColors = ['Brown', 'Grey', 'Blue Grey'];
 const mainPalette = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900];
 const altPalette = ['A100', 'A200', 'A400', 'A700'];
 
-export const styleSheet = createStyleSheet('colors', theme => ({
+export const styleSheet = createStyleSheet(theme => ({
   root: {
     display: 'flex',
     flexWrap: 'wrap',

--- a/docs/src/pages/style/Icons.js
+++ b/docs/src/pages/style/Icons.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 import Icon from 'material-ui/Icon';
 
-const styleSheet = createStyleSheet('Icons', {
+const styleSheet = createStyleSheet({
   root: {
     display: 'flex',
     alignItems: 'flex-end',

--- a/docs/src/pages/style/SvgIcons.js
+++ b/docs/src/pages/style/SvgIcons.js
@@ -9,7 +9,7 @@ import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
 import SvgIcon from 'material-ui/SvgIcon';
 
-const styleSheet = createStyleSheet('SvgIcons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   icon: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/style/SvgMaterialIcons.js
+++ b/docs/src/pages/style/SvgMaterialIcons.js
@@ -6,7 +6,7 @@ import AccessAlarmIcon from 'material-ui-icons/AccessAlarm';
 import ThreeDRotation from 'material-ui-icons/ThreeDRotation';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('SvgMaterialIcons', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   icon: {
     margin: theme.spacing.unit,
   },

--- a/docs/src/pages/style/TypographyTheme.js
+++ b/docs/src/pages/style/TypographyTheme.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles, createStyleSheet } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('TypograpghyTheme', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: theme.typography.button,
 }));
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-ui-build-next",
   "private": true,
   "author": "Material-UI Team",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Material Design UI components built with React",
   "main": "./src/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   },
   "homepage": "http://material-ui.com/",
   "scripts": {
-    "deploy": "cd docs && yarn build && firebase deploy",
+    "docs:deploy": "cd docs && yarn build && firebase deploy",
+    "docs:build": "rimraf docs/src/pages/component-api/* && babel-node ./scripts/build-api-docs.js",
     "build": "npm run build:es2015 && npm run build:es2015modules && npm run build:copy-files && npm run build:umd:dev && npm run build:umd:prod",
     "build:es2015": "cross-env NODE_ENV=production babel ./src --ignore *.spec.js --out-dir ./build",
     "build:es2015modules": "cross-env NODE_ENV=production BABEL_ENV=modules babel ./src/index.js --out-file ./build/index.es.js",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "build:umd:dev": "webpack --config scripts/umd.webpack.config.js",
     "build:umd:prod": "cross-env NODE_ENV=production webpack --config scripts/umd.webpack.config.js",
-    "build:docs": "rimraf docs/src/pages/component-api/* && babel-node ./scripts/build-api-docs.js",
     "prettier": "find . -name \"*.js\" | grep -v -f .eslintignore | xargs prettier --write --single-quote --trailing-comma all --print-width 100",
     "clean:build": "rimraf build",
     "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
@@ -45,7 +45,9 @@
     "test:regressions": "webpack --config test/regressions/webpack.config.js && vrtest run --config test/vrtest.config.js --record",
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN || true",
     "flow": "flow --show-all-errors",
-    "publish": "npm run build && cd build && npm publish --tag next"
+    "version": "yarn build",
+    "release": "np --no-publish --any-branch",
+    "postrelease": "yarn docs:deploy && npm publish build --tag next"
   },
   "peerDependencies": {
     "react": "^15.3.0 || ^16.0.0-beta.1",

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -34,7 +34,6 @@ export const styleSheet = createStyleSheet('MuiAvatar', theme => ({
 }));
 
 type DefaultProps = {
-  alt: string,
   component: string,
 };
 
@@ -142,7 +141,6 @@ function Avatar(props: Props) {
 }
 
 Avatar.defaultProps = {
-  alt: '',
   component: 'div',
 };
 

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -207,7 +207,7 @@ class Drawer extends Component<DefaultProps, Props, State> {
 
     if (docked) {
       return (
-        <div className={classNames(classes.docked, className)}>
+        <div className={classNames(classes.docked, className)} {...other}>
           {drawer}
         </div>
       );

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -1,0 +1,259 @@
+// @flow
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Card, Typography, IconButton, CardActions, CardContent } from '../';
+import Collapse from '../transitions/Collapse';
+import createStyleSheet from '../styles/createStyleSheet';
+import withStyles from '../styles/withStyles';
+
+const styleSheet = createStyleSheet('ExpansionPanel', theme => ({
+  card: {
+    margin: 0,
+    transition: theme.transitions.create('margin', {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  cardDisabled: {
+    backgroundColor: theme.palette.grey[200],
+    color: theme.palette.text.disabled,
+  },
+  cardExpanded: {
+    margin: [16, 0],
+    '&:first-child': {
+      marginTop: 0,
+    },
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    height: 48,
+    transition: theme.transitions.create('height', {
+      duration: theme.transitions.duration.shortest,
+    }),
+    padding: [0, 24],
+    '&:last-child': {
+      paddingBottom: 0,
+    },
+  },
+  headerFocused: {
+    backgroundColor: theme.palette.grey[200],
+  },
+  headerExpanded: {
+    height: 64,
+  },
+  headerClickable: {
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+  headerTitle: {
+    fontSize: 16,
+    color: theme.palette.text.primary,
+  },
+  content: {
+    padding: 0,
+    '&:last-child': {},
+  },
+  expand: {
+    width: 40,
+    height: 40,
+    marginRight: -16,
+    transform: 'rotate(0deg)',
+    transition: theme.transitions.create('transform', {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  expandOpen: {
+    transform: 'rotate(180deg)',
+  },
+  focusHolder: {
+    position: 'absolute',
+    '&:focus': {
+      outline: 'none',
+    },
+  },
+}));
+
+const enableTabbing = '0';
+const disableTabbing = '-1';
+
+/**
+ * Non-visible element to manage an interactive keyboard focus state
+ * for the ExpansionPanel component
+ */
+const KeyboardFocusHolder = props => <div {...props} />;
+
+class ExpansionPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      // TODO: fix this
+      expanded: props.expanded,
+      focused: false,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      expanded: nextProps.expanded,
+    });
+  }
+
+  onHeaderKeyUp({ keyCode }) {
+    // TODO: handle ENTER or SPACE pressed
+    if (keyCode === 13 || keyCode === 32) {
+      this.handleExpand();
+    }
+  }
+
+  handleFocus() {
+    this.setState({
+      focused: true,
+    });
+  }
+
+  handleBlur() {
+    this.setState({
+      focused: false,
+    });
+  }
+
+  handleExpand = () => {
+    const { disabled, onChange } = this.props;
+    if (disabled) {
+      return;
+    }
+    const expand = !this.state.expanded;
+    onChange(this, expand);
+    this.setState({ expanded: expand });
+  };
+
+  handleContentClick = () => {
+    const { disabled, onContentClick } = this.props;
+    if (!disabled) {
+      onContentClick(this);
+    }
+  };
+
+  render() {
+    const {
+      children,
+      classes,
+      className,
+      disabled,
+      expandIcon,
+      headerTitle,
+      unmountOnExit,
+    } = this.props;
+
+    const { expanded, focused } = this.state;
+
+    return (
+      <Card
+        className={classNames(className, classes.card, {
+          [classes.cardDisabled]: disabled,
+          [classes.cardExpanded]: expanded,
+        })}
+      >
+        <CardContent
+          className={classNames(classes.header, {
+            [classes.headerClickable]: !disabled,
+            [classes.headerExpanded]: expanded,
+            [classes.headerFocused]: focused,
+          })}
+          onClick={this.handleExpand}
+        >
+          <Typography className={classes.headerTitle}>
+            <span className={disabled && classes.cardDisabled}>
+              {headerTitle}
+            </span>
+          </Typography>
+          <CardActions className={classes.actions}>
+            <IconButton
+              disabled={disabled}
+              className={classNames(classes.expand, {
+                [classes.expandOpen]: expanded,
+              })}
+              tabIndex={disableTabbing}
+              onClick={this.handleExpand}
+            >
+              {expandIcon}
+            </IconButton>
+          </CardActions>
+        </CardContent>
+        <KeyboardFocusHolder
+          className={classes.focusHolder}
+          tabIndex={!disabled && enableTabbing}
+          onKeyUp={e => this.onHeaderKeyUp(e)}
+          onFocus={() => this.handleFocus()}
+          onBlur={() => this.handleBlur()}
+        />
+        <Collapse in={expanded} transitionDuration="auto" unmountOnExit={unmountOnExit}>
+          <CardContent className={classes.content} onClick={this.handleContentClick}>
+            {children}
+          </CardContent>
+        </Collapse>
+      </Card>
+    );
+  }
+}
+
+ExpansionPanel.propTypes = {
+  /**
+   * Pass child components
+   */
+  children: PropTypes.object,
+  /**
+   * Pass css classes definitions
+   */
+  classes: PropTypes.object,
+  /**
+   * Sets the class name of the root element
+   */
+  className: PropTypes.string,
+  /**
+   * Sets disable state of the panel
+   */
+  disabled: PropTypes.bool,
+  /**
+   * Expands or collapses the panel
+   */
+  expanded: PropTypes.bool,
+  /**
+   * Sets the title of the panel header
+   */
+  headerTitle: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  /**
+   * Unmounts the child elements after collapse the panel
+   * Pay attention to (redux) forms
+   */
+  unmountOnExit: PropTypes.bool,
+  /**
+   * Fired on every expand/collapse state change
+   */
+  onChange: PropTypes.func,
+  /**
+   * Fired when the user clicks on expanded content of the panel
+   */
+  onContentClick: PropTypes.func,
+};
+
+ExpansionPanel.defaultProps = {
+  children: null,
+  classes: {},
+  className: '',
+  disabled: false,
+  expanded: false,
+  headerTitle: '',
+  unmountOnExit: false,
+  onChange: () => true,
+  onContentClick: () => {},
+};
+
+export default withStyles(styleSheet)(ExpansionPanel);

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -9,18 +9,18 @@ import Collapse from '../transitions/Collapse';
 import createStyleSheet from '../styles/createStyleSheet';
 import withStyles from '../styles/withStyles';
 
-const styleSheet = createStyleSheet('MuiExpansionPanel', theme => ({
-  card: {
+export const styleSheet = createStyleSheet('MuiExpansionPanel', theme => ({
+  root: {
     margin: 0,
     transition: theme.transitions.create('margin', {
       duration: theme.transitions.duration.shortest,
     }),
   },
-  cardDisabled: {
+  disabled: {
     backgroundColor: theme.palette.grey[200],
     color: theme.palette.text.disabled,
   },
-  cardExpanded: {
+  expanded: {
     margin: [theme.spacing.unit * 2, 0],
     '&:first-child': {
       marginTop: 0,
@@ -45,7 +45,7 @@ const styleSheet = createStyleSheet('MuiExpansionPanel', theme => ({
   headerExpanded: {
     height: 64,
   },
-  headerEnabled: {
+  headerHover: {
     '&:hover': {
       cursor: 'pointer',
     },
@@ -53,11 +53,7 @@ const styleSheet = createStyleSheet('MuiExpansionPanel', theme => ({
   headerDisabled: {
     opacity: 0.38,
   },
-  content: {
-    padding: 0,
-    '&:last-child': {},
-  },
-  expand: {
+  expandButton: {
     width: 40,
     height: 40,
     marginRight: -theme.spacing.unit * 2,
@@ -66,7 +62,7 @@ const styleSheet = createStyleSheet('MuiExpansionPanel', theme => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
-  expandOpen: {
+  expandButtonOpen: {
     transform: 'rotate(180deg)',
   },
   focusHolder: {
@@ -84,7 +80,6 @@ class ExpansionPanel extends Component {
   static defaultProps = {
     disabled: false,
     expandIcon: null,
-    headerTitle: '',
     onChange: () => {},
     unmountOnExit: false,
   };
@@ -149,7 +144,7 @@ class ExpansionPanel extends Component {
     return (
       <ComponentProp
         className={classNames(classes.header, {
-          [classes.headerEnabled]: !disabled,
+          [classes.headerHover]: !disabled,
           [classes.headerExpanded]: expanded,
           [classes.headerFocused]: focused,
         })}
@@ -168,8 +163,8 @@ class ExpansionPanel extends Component {
         {expandIcon &&
           <IconButton
             disabled={disabled}
-            className={classNames(classes.expand, {
-              [classes.expandOpen]: expanded,
+            className={classNames(classes.expandButton, {
+              [classes.expandButtonOpen]: expanded,
             })}
             component="div"
             tabIndex={disableTabbing}
@@ -200,9 +195,9 @@ class ExpansionPanel extends Component {
     const { expanded } = this.state;
     return (
       <Card
-        className={classNames(className, classes.card, {
-          [classes.cardDisabled]: disabled,
-          [classes.cardExpanded]: expanded,
+        className={classNames(className, classes.root, {
+          [classes.disabled]: disabled,
+          [classes.expanded]: expanded,
         })}
       >
         {this.renderHeader()}
@@ -219,7 +214,7 @@ ExpansionPanel.propTypes = {
   /**
    * The content of the expansion panel.
    */
-  children: PropTypes.node,
+  children: PropTypes.element,
   /**
    * Useful to extend the style applied to components.
    */
@@ -244,11 +239,11 @@ ExpansionPanel.propTypes = {
   /**
    * The icon to display as the expand indicator.
    */
-  expandIcon: PropTypes.node,
+  expandIcon: PropTypes.element,
   /**
    * Sets the title of the panel header.
    */
-  headerTitle: PropTypes.node,
+  headerTitle: PropTypes.element,
   /**
    * Properties applied to the header title Typography element.
    */

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -81,19 +81,36 @@ const enableTabbing = '0';
 const disableTabbing = '-1';
 
 class ExpansionPanel extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      expanded: props.expanded,
-      focused: false,
-    };
+  static defaultProps = {
+    disabled: false,
+    expandIcon: null,
+    headerTitle: '',
+    onChange: () => {},
+    unmountOnExit: false,
+  };
+
+  state = {
+    expanded: false,
+    focused: false,
+  };
+
+  componentWillMount() {
+    const { expanded, defaultExpanded } = this.props;
+    this.isControlled = expanded !== undefined;
+    this.setState({
+      expanded: this.isControlled ? expanded : defaultExpanded,
+    });
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({
-      expanded: nextProps.expanded,
-    });
+    if (this.isControlled) {
+      this.setState({
+        expanded: nextProps.expanded,
+      });
+    }
   }
+
+  isControlled = null;
 
   onHeaderKeyUp({ keyCode }) {
     if (keyCode === codes.enter || keyCode === codes.space) {
@@ -120,7 +137,9 @@ class ExpansionPanel extends Component {
     }
     const expand = !this.state.expanded;
     onChange(this, expand);
-    this.setState({ expanded: expand });
+    if (!this.isControlled) {
+      this.setState({ expanded: expand });
+    }
   };
 
   renderHeader() {
@@ -210,11 +229,16 @@ ExpansionPanel.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, expands the panel by default.
+   */
+  defaultExpanded: PropTypes.bool,
+  /**
    * If `true`, the panel should be displayed in a disabled state.
    */
   disabled: PropTypes.bool,
   /**
    * If `true`, expands the panel, otherwise collapse it.
+   * Setting this prop enables control over the panel.
    */
   expanded: PropTypes.bool,
   /**
@@ -237,15 +261,6 @@ ExpansionPanel.propTypes = {
    * Unmounts the child elements after collapse the panel.
    */
   unmountOnExit: PropTypes.bool,
-};
-
-ExpansionPanel.defaultProps = {
-  disabled: false,
-  expanded: false,
-  expandIcon: null,
-  headerTitle: '',
-  onChange: () => {},
-  unmountOnExit: false,
 };
 
 export default withStyles(styleSheet)(ExpansionPanel);

--- a/src/ExpansionPanel/index.js
+++ b/src/ExpansionPanel/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export { default } from './ExpansionPanel';

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -12,6 +12,7 @@ export const styleSheet = createStyleSheet('MuiFormControlLabel', theme => ({
     display: 'inline-flex',
     alignItems: 'center',
     cursor: 'pointer',
+    // Remove Gray Highlight
     WebkitTapHighlightColor: theme.palette.common.transparent,
   },
   disabled: {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -85,6 +85,7 @@ export const styleSheet = createStyleSheet('MuiMenu', {
      * the menu.
      */
     maxHeight: 'calc(100vh - 96px)',
+    WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
   },
 });
 
@@ -126,9 +127,8 @@ class Menu extends Component<DefaultProps, Props, void> {
   handleListKeyDown = (event: SyntheticUIEvent, key: string) => {
     if (key === 'tab') {
       event.preventDefault();
-      const { onRequestClose } = this.props;
-      if (onRequestClose) {
-        return onRequestClose(event);
+      if (this.props.onRequestClose) {
+        return this.props.onRequestClose(event);
       }
     }
 

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -177,7 +177,7 @@ function TextField(props: Props) {
       {...other}
     >
       {label &&
-        <InputLabel className={labelClassName} {...InputLabelProps}>
+        <InputLabel htmlFor={id} className={labelClassName} {...InputLabelProps}>
           {label}
         </InputLabel>}
       <Input

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ export {
 export { default as Divider } from './Divider';
 export { default as Drawer } from './Drawer';
 
+export { default as ExpansionPanel } from './ExpansionPanel';
+
 export { FormControl, FormGroup, FormLabel, FormHelperText, FormControlLabel } from './Form';
 
 export { default as Hidden } from './Hidden';

--- a/src/internal/Backdrop.js
+++ b/src/internal/Backdrop.js
@@ -14,13 +14,15 @@ export const styleSheet = createStyleSheet('MuiBackdrop', theme => ({
     position: 'fixed',
     top: 0,
     left: 0,
+    // Remove Gray Highlight
+    WebkitTapHighlightColor: theme.palette.common.transparent,
     backgroundColor: theme.palette.common.lightBlack,
     transition: theme.transitions.create('opacity'),
     willChange: 'opacity',
     opacity: 0,
   },
   invisible: {
-    backgroundColor: 'rgba(0, 0, 0, 0)',
+    backgroundColor: theme.palette.common.transparent,
   },
 }));
 

--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -10,10 +10,11 @@ import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../uti
 import TouchRipple from './TouchRipple';
 import createRippleHandler from './createRippleHandler';
 
-export const styleSheet = createStyleSheet('MuiButtonBase', {
+export const styleSheet = createStyleSheet('MuiButtonBase', theme => ({
   root: {
     position: 'relative',
-    WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+    // Remove Gray Highlight
+    WebkitTapHighlightColor: theme.palette.common.transparent,
     outline: 'none',
     border: 0,
     cursor: 'pointer',
@@ -26,7 +27,7 @@ export const styleSheet = createStyleSheet('MuiButtonBase', {
   disabled: {
     cursor: 'default',
   },
-});
+}));
 
 type DefaultProps = {
   centerRipple: boolean,

--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -111,7 +111,12 @@ class ButtonBase extends Component<DefaultProps, Props, State> {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    if (this.props.focusRipple && nextState.keyboardFocused && !this.state.keyboardFocused) {
+    if (
+      this.props.focusRipple &&
+      nextState.keyboardFocused &&
+      !this.state.keyboardFocused &&
+      !this.props.disableRipple
+    ) {
       this.ripple.pulsate();
     }
   }

--- a/src/internal/ButtonBase.js
+++ b/src/internal/ButtonBase.js
@@ -196,6 +196,7 @@ class ButtonBase extends Component<DefaultProps, Props, State> {
   });
 
   handleTouchStart = createRippleHandler(this, 'TouchStart', 'start');
+
   handleTouchEnd = createRippleHandler(this, 'TouchEnd', 'stop');
 
   handleBlur = createRippleHandler(this, 'Blur', 'stop', () => {

--- a/src/internal/Popover.js
+++ b/src/internal/Popover.js
@@ -95,7 +95,8 @@ type Props = DefaultProps & {
   anchorEl?: Object,
   /**
    * This is the point on the anchor where the popover's
-   * `targetOrigin` will attach to.
+   * `anchorEl` will attach to.
+   *
    * Options:
    * vertical: [top, center, bottom];
    * horizontal: [left, center, right].
@@ -366,6 +367,7 @@ class Popover extends Component<DefaultProps, Props, void> {
 
   handleGetOffsetTop = getOffsetTop;
   handleGetOffsetLeft = getOffsetLeft;
+
   /**
    * Returns the top/left offset of the position
    * to attach to on the anchor element (or body if none is provided)

--- a/src/internal/createRippleHandler.js
+++ b/src/internal/createRippleHandler.js
@@ -1,7 +1,7 @@
-// @flow weak
+// @flow
 
-export default function createRippleHandler(instance, eventName, action, cb) {
-  return function handleEvent(event) {
+function createRippleHandler(instance: Object, eventName: string, action: string, cb: ?Function) {
+  return function handleEvent(event: SyntheticUIEvent) {
     if (cb) {
       cb.call(instance, event);
     }
@@ -21,3 +21,5 @@ export default function createRippleHandler(instance, eventName, action, cb) {
     return true;
   };
 }
+
+export default createRippleHandler;

--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -31,6 +31,6 @@ export default function createGenerateClassName(): generateClassName {
       return `${sheet.options.meta}-${rule.key}-${ruleCounter}`;
     }
 
-    return `${rule.key}-${ruleCounter.toString(36)}`;
+    return `${rule.key}-${ruleCounter}`;
   };
 }

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -31,7 +31,7 @@ describe('createGenerateClassName', () => {
       assert.strictEqual(generateClassName(rule, sheet), 'Button-root-1');
     });
 
-    it('should use a base 36 representation', () => {
+    it('should use a base 10 representation', () => {
       const rule = {
         key: 'root',
       };
@@ -45,10 +45,7 @@ describe('createGenerateClassName', () => {
       assert.strictEqual(generateClassName(rule), 'root-7');
       assert.strictEqual(generateClassName(rule), 'root-8');
       assert.strictEqual(generateClassName(rule), 'root-9');
-      assert.strictEqual(generateClassName(rule), 'root-a');
-      assert.strictEqual(generateClassName(rule), 'root-b');
-      assert.strictEqual(generateClassName(rule), 'root-c');
-      assert.strictEqual(generateClassName(rule), 'root-d');
+      assert.strictEqual(generateClassName(rule), 'root-10');
     });
 
     describe('production', () => {

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -134,8 +134,17 @@ const withStyles = (styleSheet: Array<Object> | Object, options: Object = {}) =>
 
         if (sheetManagerTheme.refs === 0) {
           const styles = currentStyleSheet.createStyles(theme);
+          let meta;
+
+          if (process.env.NODE_ENV !== 'production') {
+            meta = currentStyleSheet.name ? currentStyleSheet.name : getDisplayName(BaseComponent);
+            // Sanitize the string as will be used in development to prefix the generated
+            // class name.
+            meta = meta.replace(new RegExp(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g), '-');
+          }
+
           const sheet = this.jss.createStyleSheet(styles, {
-            meta: currentStyleSheet.name ? currentStyleSheet.name : getDisplayName(BaseComponent),
+            meta,
             link: false,
             ...this.sheetOptions,
             ...currentStyleSheet.options,

--- a/test/integration/fixtures/menus/SimpleMenu.js
+++ b/test/integration/fixtures/menus/SimpleMenu.js
@@ -5,7 +5,7 @@ import Menu, { MenuItem } from 'src/Menu';
 
 const options = ['Menu Item 1', 'Menu Item 2', 'Menu Item 3'];
 
-export default class SimpleMenu extends Component {
+class SimpleMenu extends Component {
   state = {
     anchorEl: undefined,
     open: false,
@@ -45,3 +45,5 @@ export default class SimpleMenu extends Component {
     );
   }
 }
+
+export default SimpleMenu;

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 
-const styleSheet = createStyleSheet('TestViewer', theme => {
+const styleSheet = createStyleSheet(theme => {
   return {
     '@global': {
       html: {

--- a/test/regressions/tests/Grid/AutoGrid.js
+++ b/test/regressions/tests/Grid/AutoGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('AutoGrid', () => ({
+const styleSheet = createStyleSheet(() => ({
   root: {
     width: 400,
   },

--- a/test/regressions/tests/Grid/SimpleGrid.js
+++ b/test/regressions/tests/Grid/SimpleGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('SimpleGrid', () => ({
+const styleSheet = createStyleSheet(() => ({
   root: {
     width: 400,
   },

--- a/test/regressions/tests/Grid/StressGrid.js
+++ b/test/regressions/tests/Grid/StressGrid.js
@@ -6,7 +6,7 @@ import Paper from 'material-ui/Paper';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Grid from 'material-ui/Grid';
 
-const styleSheet = createStyleSheet('StressGrid', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 400,
     backgroundColor: theme.palette.primary.A400,

--- a/test/regressions/tests/Input/InputLabels.js
+++ b/test/regressions/tests/Input/InputLabels.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import InputLabel from 'material-ui/Input/InputLabel';
 
-const styleSheet = createStyleSheet('InputLabels', () => ({
+const styleSheet = createStyleSheet(() => ({
   container: {
     display: 'flex',
     flexDirection: 'column',

--- a/test/regressions/tests/Input/Inputs.js
+++ b/test/regressions/tests/Input/Inputs.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { createStyleSheet, withStyles } from 'material-ui/styles';
 import Input from 'material-ui/Input/Input';
 
-const styleSheet = createStyleSheet('Inputs', () => ({
+const styleSheet = createStyleSheet(() => ({
   container: {
     display: 'flex',
     flexDirection: 'column',

--- a/test/regressions/tests/Tabs/AdvancedTabs.js
+++ b/test/regressions/tests/Tabs/AdvancedTabs.js
@@ -8,7 +8,7 @@ import Paper from 'material-ui/Paper';
 import Tabs from 'material-ui/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
 
-const styleSheet = createStyleSheet('AdvancedTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 600,
   },

--- a/test/regressions/tests/Tabs/SimpleTabs.js
+++ b/test/regressions/tests/Tabs/SimpleTabs.js
@@ -8,7 +8,7 @@ import Paper from 'material-ui/Paper';
 import Tabs from 'material-ui/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
 
-const styleSheet = createStyleSheet('SimpleTabs', theme => ({
+const styleSheet = createStyleSheet(theme => ({
   root: {
     width: 600,
   },


### PR DESCRIPTION
@andrzejbk - I'm making a test PR in our repo just to see how it looks

- [ ] PR has tests / docs demo, and is linted.
- [x] PR docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

This is a pull request for the Expansion Panel Component specified in the [Material UI Design Specifications](https://material.io/guidelines/components/expansion-panels.html). 

There are no tests written for this component so far. However I would like to add them with feedback from the contributors.

There is a demo for two main case of use of the component (standalone Expansion Panel / controlled Expansion Panel - like accordion) included in documentation section. This is apart of the #2863 Issue.
This PR is up-to-date with the v1-beta branch as of Jul 29, 2017 (v1.0.0-beta.3 tag).