### PR TITLE
[ExpansionPanel] change check ExpansionPanelSummary element

### DIFF
--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import Collapse from '../transitions/Collapse';
 import Paper from '../Paper';
 import withStyles from '../styles/withStyles';
+import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = (theme: Object) => {
   const transition = {
@@ -186,7 +187,7 @@ class ExpansionPanel extends React.Component<AllProps, State> {
     let summary = null;
 
     const children = React.Children.map(childrenProp, child => {
-      if (child.type.name === 'withStyles(ExpansionPanelSummary)') {
+      if (isMuiElement(child, ['ExpansionPanelSummary'])) {
         summary = React.cloneElement(child, {
           disabled,
           expanded: this.state.expanded,

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -118,6 +118,8 @@ type State = {
 class ExpansionPanelSummary extends React.Component<AllProps, State> {
   props: AllProps;
 
+  static muiName = 'ExpansionPanelSummary';
+
   static defaultProps = {
     classes: {},
     disabled: false,
@@ -188,7 +190,5 @@ class ExpansionPanelSummary extends React.Component<AllProps, State> {
     );
   }
 }
-
-ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
 
 export default withStyles(styles)(ExpansionPanelSummary);

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -189,4 +189,6 @@ class ExpansionPanelSummary extends React.Component<AllProps, State> {
   }
 }
 
+ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
+
 export default withStyles(styles)(ExpansionPanelSummary);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -70,7 +70,10 @@ export {
 } from './Dialog';
 export { default as Divider } from './Divider';
 export { default as Drawer } from './Drawer';
-export { ExpansionPanel, ExpansionPanelSummary } from './ExpansionPanel';
+export {
+  default as ExpansionPanel,
+  ExpansionPanelSummary,
+} from './ExpansionPanel';
 export { FormControl, FormGroup, FormLabel, FormHelperText, FormControlLabel } from './Form';
 export { default as Hidden } from './Hidden';
 export { default as Icon } from './Icon';


### PR DESCRIPTION
- [ ] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

hi
what do you think about check mui element code like https://github.com/discussio/material-ui/blob/v1-expansion-panel/src/List/ListItem.js#L143?
#### from
```js
child.type.name === 'withStyles(ExpansionPanelSummary)'
```
#### to
```js
isMuiElement(child, ['ExpansionPanelSummary'])
```
